### PR TITLE
Build on older ghcs

### DIFF
--- a/focuslist.cabal
+++ b/focuslist.cabal
@@ -30,7 +30,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.FocusList
   build-depends:       base >= 4.7 && < 5
-                     , containers
+                     , containers >= 0.5.8
                      , lens
                      , mono-traversable
                      , QuickCheck

--- a/focuslist.cabal
+++ b/focuslist.cabal
@@ -29,7 +29,7 @@ flag buildreadme
 library
   hs-source-dirs:      src
   exposed-modules:     Data.FocusList
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , containers >= 0.5.8
                      , lens
                      , mono-traversable

--- a/src/Data/FocusList.hs
+++ b/src/Data/FocusList.hs
@@ -78,6 +78,7 @@ import Data.Foldable (toList)
 import Data.Function ((&))
 import Data.MonoTraversable
   (Element, GrowingAppend, MonoFoldable, MonoFunctor, MonoTraversable, olength)
+import Data.Semigroup ((<>))
 import qualified Data.Sequence as Sequence
 import Data.Sequence
   (Seq((:<|), Empty), (<|), deleteAt, elemIndexL, insertAt, singleton)


### PR DESCRIPTION
This fixes compilation back to GHC 8.0, and signals incompatibility below that version.
As a hackage trustee, I have revised the version bounds on the existing release of focuslist, as it did not build below GHC 8.4