### PR TITLE
Fix tests for >=tasty-hspec-1.1.7

### DIFF
--- a/focuslist.cabal
+++ b/focuslist.cabal
@@ -60,6 +60,7 @@ test-suite focuslist-test
                      , genvalidity-containers >= 0.5
                      , genvalidity-hspec >= 0.6
                      , hedgehog >= 0.6.1
+                     , hspec
                      , lens
                      , QuickCheck
                      , tasty >= 1.1

--- a/test/Test/FocusList.hs
+++ b/test/Test/FocusList.hs
@@ -5,10 +5,11 @@
 module Test.FocusList where
 
 import Data.GenValidity.Sequence ()
+import Test.Hspec (Spec)
 import Test.QuickCheck (Gen)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
-import Test.Tasty.Hspec (Spec, testSpec)
+import Test.Tasty.Hspec (testSpec)
 import Test.Validity (GenInvalid, GenUnchecked, GenValid(genValid), Validity(validate), check, eqSpec, genValidSpec)
 
 import Data.FocusList (Focus, FocusList, genValidFL, invariantFL)


### PR DESCRIPTION
`Spec` is no longer re-exported in `tasty-hspec-1.1.7`:

https://github.com/mitchellwrosen/tasty-hspec/commit/640f5973b4bca0c6c3e01d4fab4528aa08da22e9#diff-aa396797a3d6306aa116e2b7625e44e1065d3ab547143569d4febace859d5859L18-L19